### PR TITLE
fix: pastedData could be undefined

### DIFF
--- a/src/components/TwemojiTextarea.vue
+++ b/src/components/TwemojiTextarea.vue
@@ -281,7 +281,7 @@ export default Vue.extend({
         this.twemojiPicker.$refs.popupEmoji.popperInstance.forceUpdate();
     },
     onPaste(pasteEvent: ClipboardEvent): void {
-      let pastedData;
+      let pastedData = '';
 
       pasteEvent.stopPropagation();
       pasteEvent.preventDefault();


### PR DESCRIPTION
 - while removing optional chaining, I made a mistake by moving a line using optional chaining inside an if. The line also initialized the `pastedData` variable.
 - The solution was to initialize the variable where it's declared.
 - I also left the `|| ''` inside the conditional in case `clipboardData.getData('text')` returns an undefined value.